### PR TITLE
Restore alphabetical ordering in workflow frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Official building blocks appear here alongside ecosystem standards that help mak
 
 These are the repositories where the workflow itself is the product. The two `oh-my-codex` entries are distinct projects with different workflow models.
 
-- [shinpr/codex-workflows](https://github.com/shinpr/codex-workflows) - Codex workflows organized around user-value slices so features get designed, tested, and integrated earlier instead of breaking at the end; each slice is grounded in design docs, test skeletons, TDD, and quality gates.
 - [am-will/swarms](https://github.com/am-will/swarms) - Dependency-aware workflow skills for Codex and Claude that make parallel execution safer through explicit `depends_on` plans, wave execution, and TDD-oriented validation.
+- [shinpr/codex-workflows](https://github.com/shinpr/codex-workflows) - Codex workflows organized around user-value slices so features get designed, tested, and integrated earlier instead of breaking at the end; each slice is grounded in design docs, test skeletons, TDD, and quality gates.
 - [staticpayload/oh-my-codex](https://github.com/staticpayload/oh-my-codex) - Codex-native orchestration product built around `.omx/` state, review queues, and tmux team runtime so long-running work can be resumed instead of reassembled from chat history.
 - [Yeachan-Heo/oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - Workflow layer for Codex organized around OMX modes like `$deep-interview`, `$ralplan`, `$ralph`, and `$team`, giving one repeatable path from clarification to completion.
 

--- a/scripts/lib/readme-generator.mjs
+++ b/scripts/lib/readme-generator.mjs
@@ -92,22 +92,5 @@ function orderRepos(category, repos) {
     });
   }
 
-  if (category === "Codex Workflow Frameworks") {
-    const priority = new Map([
-      ["shinpr/codex-workflows", 0]
-    ]);
-
-    return [...repos].sort((a, b) => {
-      const aPriority = priority.get(a.name);
-      const bPriority = priority.get(b.name);
-
-      if (aPriority !== undefined || bPriority !== undefined) {
-        return (aPriority ?? Number.MAX_SAFE_INTEGER) - (bPriority ?? Number.MAX_SAFE_INTEGER);
-      }
-
-      return a.name.localeCompare(b.name, "en");
-    });
-  }
-
   return [...repos].sort((a, b) => a.name.localeCompare(b.name, "en"));
 }


### PR DESCRIPTION
## Summary
- remove the special-case ordering for `shinpr/codex-workflows`
- restore alphabetical ordering in the Codex Workflow Frameworks section

## Validation
- `node scripts/generate-readme.mjs`
- `node scripts/validate-repos.mjs`
- `node scripts/check-readme.mjs`