### PR TITLE
Clarify meta-harness provenance in curated copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These are the repositories where the workflow itself is the product: planning, e
 These repositories help people design, support, or operate Codex workflows, even when the workflow itself lives elsewhere.
 
 - [milisp/codexia](https://github.com/milisp/codexia) - Tauri-based desktop console for Codex and Claude Code, built to run many agent tasks at once with scheduling, worktrees, remote control, and a headless web companion.
-- [SaehwanPark/meta-harness](https://github.com/SaehwanPark/meta-harness) - Codex-native workflow design kit for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.
+- [SaehwanPark/meta-harness](https://github.com/SaehwanPark/meta-harness) - Codex-oriented adaptation of revfactory/harness for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.
 - [shouc/agentflow](https://github.com/shouc/agentflow) - Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.
 - [xintaofei/codeg](https://github.com/xintaofei/codeg) - Shared coding workspace for multi-agent teams, tying together session aggregation, worktrees, MCP management, browser access, and chat-channel control across desktop and server surfaces.

--- a/data/repos/SaehwanPark--meta-harness.json
+++ b/data/repos/SaehwanPark--meta-harness.json
@@ -1,7 +1,7 @@
 {
   "name": "SaehwanPark/meta-harness",
   "url": "https://github.com/SaehwanPark/meta-harness",
-  "summary": "Codex-native workflow design kit for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.",
+  "summary": "Codex-oriented adaptation of revfactory/harness for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.",
   "codex_relation": "adjacent",
   "category": "Workflow Infrastructure & Design",
   "tags": [
@@ -14,7 +14,7 @@
     "workflow-patterns"
   ],
   "evidence": [
-    "Provides a Codex-native harness skill for designing repo-local workflows, specialist roles, and deterministic handoff artifacts.",
+    "Adapts revfactory/harness into an AGENTS.md and .agents/skills layout so the same design-kit idea works as a repo-local Codex workflow system.",
     "Uses explicit architecture patterns, role boundaries, and _workspace artifact contracts rather than a generic prompt pack."
   ],
   "status": "active"


### PR DESCRIPTION
## Summary
This PR clarifies the curated description for `SaehwanPark/meta-harness` so its provenance is explicit in both the repo data and generated README.

## What changed
- updates the one-line summary to describe `meta-harness` as a Codex-oriented adaptation of `revfactory/harness`
- adjusts the supporting evidence to reflect the AGENTS.md / `.agents/skills` port more directly
- regenerates the README entry from the updated repo data

## Why
The previous wording captured the repo's design value, but it did not make the adaptation lineage visible enough. This keeps the curation accurate without changing the inclusion decision.

## Validation
- `node scripts/generate-readme.mjs`
- `node scripts/validate-repos.mjs`
- `node scripts/check-readme.mjs`
