### PR TITLE
Add Agor and refresh renamed repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ These are the repositories where the workflow itself is the product: planning, e
 
 - [am-will/swarms](https://github.com/am-will/swarms) - Dependency-aware workflow skills for Codex and Claude that make parallel execution safer through explicit `depends_on` plans, wave execution, and TDD-oriented validation.
 - [Phlegonlabs/Harness-Engineering-skills](https://github.com/Phlegonlabs/Harness-Engineering-skills) - Repo-backed PRD-to-code workflow skills for Claude and Codex that turn planning into durable project state with phase gates, approval stops, and validation instead of free-form prompt chains.
+- [scalarian/oh-my-codex](https://github.com/scalarian/oh-my-codex) - Codex-native orchestration product built around `.omx/` state, review queues, and tmux team runtime so long-running work can be resumed instead of reassembled from chat history.
 - [shinpr/codex-workflows](https://github.com/shinpr/codex-workflows) - Codex workflows organized around user-value slices so features get designed, tested, and integrated earlier instead of breaking at the end; each slice is grounded in design docs, test skeletons, TDD, and quality gates.
-- [staticpayload/oh-my-codex](https://github.com/staticpayload/oh-my-codex) - Codex-native orchestration product built around `.omx/` state, review queues, and tmux team runtime so long-running work can be resumed instead of reassembled from chat history.
 - [Yeachan-Heo/oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - Workflow layer for Codex organized around OMX modes like `$deep-interview`, `$ralplan`, `$ralph`, and `$team`, giving one repeatable path from clarification to completion.
 
 ## Workflow Infrastructure & Design
 
 These repositories help people design, support, or operate Codex workflows, even when the workflow itself lives elsewhere.
 
+- [berabuddies/agentflow](https://github.com/berabuddies/agentflow) - Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.
 - [milisp/codexia](https://github.com/milisp/codexia) - Tauri-based desktop console for Codex and Claude Code, built to run many agent tasks at once with scheduling, worktrees, remote control, and a headless web companion.
 - [SaehwanPark/meta-harness](https://github.com/SaehwanPark/meta-harness) - Codex-oriented adaptation of revfactory/harness for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.
-- [shouc/agentflow](https://github.com/shouc/agentflow) - Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.
 - [xintaofei/codeg](https://github.com/xintaofei/codeg) - Shared coding workspace for multi-agent teams, tying together session aggregation, worktrees, MCP management, browser access, and chat-channel control across desktop and server surfaces.
 
@@ -65,6 +65,7 @@ These repositories are useful comparisons or integrations. Some are official, bu
 - [jonwiggins/optio](https://github.com/jonwiggins/optio) - PR-lifecycle worker system that turns CI failures, review requests, and merge conflicts into explicit resume actions, pushing tasks from intake to merged PR through a BullMQ-backed state machine.
 - [kingbootoshi/codex-orchestrator](https://github.com/kingbootoshi/codex-orchestrator) - Claude Code plugin and CLI for offloading long-running or parallel coding work to Codex jobs that can be monitored, redirected, and captured through tmux sessions.
 - [OpenAI/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) - Official Claude Code plugin that brings Codex into Claude-centered workflows for review, adversarial review, delegated rescue tasks, and optional review gates.
+- [preset-io/agor](https://github.com/preset-io/agor) - Spatial multiplayer control plane for Claude Code, Codex, and Gemini that ties sessions to worktrees, workflow zones, and isolated environments instead of treating agent runs as disconnected terminals.
 - [stellarlinkco/myclaude](https://github.com/stellarlinkco/myclaude) - Claude-centered multi-agent workflow system that routes execution to Codex, Gemini, Claude, or OpenCode backends through reusable modules like do, omo, BMAD, and SPARV.
 
 <!-- GENERATED:REPO-LIST:END -->

--- a/data/repos/berabuddies--agentflow.json
+++ b/data/repos/berabuddies--agentflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "shouc/agentflow",
-  "url": "https://github.com/shouc/agentflow",
+  "name": "berabuddies/agentflow",
+  "url": "https://github.com/berabuddies/agentflow",
   "summary": "Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.",
   "codex_relation": "adjacent",
   "category": "Workflow Infrastructure & Design",

--- a/data/repos/preset-io--agor.json
+++ b/data/repos/preset-io--agor.json
@@ -1,0 +1,21 @@
+{
+  "name": "preset-io/agor",
+  "url": "https://github.com/preset-io/agor",
+  "summary": "Spatial multiplayer control plane for Claude Code, Codex, and Gemini that ties sessions to worktrees, workflow zones, and isolated environments instead of treating agent runs as disconnected terminals.",
+  "codex_relation": "appendix",
+  "category": "Cross-Agent References",
+  "tags": [
+    "cross-agent",
+    "spatial-canvas"
+  ],
+  "signals": [
+    "worktrees",
+    "scheduler",
+    "environment-isolation"
+  ],
+  "evidence": [
+    "Backs its canvas model with real services for worktrees, sessions, scheduler, health monitoring, MCP servers, and board objects rather than a thin UI wrapper.",
+    "Includes a dedicated Codex executor path while keeping the product intentionally cross-agent, making it a strong comparison point rather than a Codex-first framework."
+  ],
+  "status": "active"
+}

--- a/data/repos/scalarian--oh-my-codex.json
+++ b/data/repos/scalarian--oh-my-codex.json
@@ -1,6 +1,6 @@
 {
-  "name": "staticpayload/oh-my-codex",
-  "url": "https://github.com/staticpayload/oh-my-codex",
+  "name": "scalarian/oh-my-codex",
+  "url": "https://github.com/scalarian/oh-my-codex",
   "summary": "Codex-native orchestration product built around `.omx/` state, review queues, and tmux team runtime so long-running work can be resumed instead of reassembled from chat history.",
   "codex_relation": "primary",
   "category": "Codex Workflow Frameworks",

--- a/scripts/check-readme.mjs
+++ b/scripts/check-readme.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { generateReadmeContent } from "./lib/readme-generator.mjs";
 
 const before = fs.readFileSync("README.md", "utf8");
-const after = generateReadmeContent(before);
+const after = generateReadmeContent(before, process.cwd());
 
 if (before !== after) {
   console.error("README.md is out of date. Run: node scripts/generate-readme.mjs");


### PR DESCRIPTION
## Summary
- add `preset-io/agor` to `Cross-Agent References`
- refresh the renamed repository links for `scalarian/oh-my-codex` and `berabuddies/agentflow`

## Notes
- README was regenerated from `data/repos`
- repo data validation and README checks pass