### PR TITLE
Add flow-next and vnx-orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Official building blocks appear here alongside ecosystem standards that help mak
 These are the repositories where the workflow itself is the product: planning, execution, review, and handoff are built into the system rather than added on around it.
 
 - [am-will/swarms](https://github.com/am-will/swarms) - Dependency-aware workflow skills for Codex and Claude that make parallel execution safer through explicit `depends_on` plans, wave execution, and TDD-oriented validation.
+- [gmickel/flow-next](https://github.com/gmickel/flow-next) - Plan-first workflow plugin for Codex, Claude Code, Factory Droid, and OpenCode with in-repo `.flow/` state, dependency-aware task graphs, re-anchoring, and cross-model reviews.
 - [Phlegonlabs/Harness-Engineering-skills](https://github.com/Phlegonlabs/Harness-Engineering-skills) - Repo-backed PRD-to-code workflow skills for Claude and Codex that turn planning into durable project state with phase gates, approval stops, and validation instead of free-form prompt chains.
 - [scalarian/oh-my-codex](https://github.com/scalarian/oh-my-codex) - Codex-native orchestration product built around `.omx/` state, review queues, and tmux team runtime so long-running work can be resumed instead of reassembled from chat history.
 - [shinpr/codex-workflows](https://github.com/shinpr/codex-workflows) - Codex workflows organized around user-value slices so features get designed, tested, and integrated earlier instead of breaking at the end; each slice is grounded in design docs, test skeletons, TDD, and quality gates.
+- [Vinix24/vnx-orchestration](https://github.com/Vinix24/vnx-orchestration) - Governance-first workflow runtime for Codex, Claude Code, and Gemini CLI that coordinates parallel agents across tmux panes with an append-only receipt ledger, quality gates, worktrees, and automatic context rotation.
 - [Yeachan-Heo/oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - Workflow layer for Codex organized around OMX modes like `$deep-interview`, `$ralplan`, `$ralph`, and `$team`, giving one repeatable path from clarification to completion.
 
 ## Workflow Infrastructure & Design

--- a/data/repos/Vinix24--vnx-orchestration.json
+++ b/data/repos/Vinix24--vnx-orchestration.json
@@ -1,0 +1,22 @@
+{
+  "name": "Vinix24/vnx-orchestration",
+  "url": "https://github.com/Vinix24/vnx-orchestration",
+  "summary": "Governance-first workflow runtime for Codex, Claude Code, and Gemini CLI that coordinates parallel agents across tmux panes with an append-only receipt ledger, quality gates, worktrees, and automatic context rotation.",
+  "codex_relation": "primary",
+  "category": "Codex Workflow Frameworks",
+  "tags": [
+    "governance",
+    "parallel-execution"
+  ],
+  "signals": [
+    "receipts",
+    "deterministic-gates",
+    "provenance",
+    "queue-reconciliation"
+  ],
+  "evidence": [
+    "Treats Codex as a first-class worker in a provider-neutral runtime rather than as a shallow optional backend.",
+    "Uses receipts, provenance, deterministic gates, worktrees, and reconciliation to control execution drift during parallel runs instead of relying on late review alone."
+  ],
+  "status": "active"
+}

--- a/data/repos/gmickel--flow-next.json
+++ b/data/repos/gmickel--flow-next.json
@@ -1,0 +1,22 @@
+{
+  "name": "gmickel/flow-next",
+  "url": "https://github.com/gmickel/flow-next",
+  "summary": "Plan-first workflow plugin for Codex, Claude Code, Factory Droid, and OpenCode with in-repo `.flow/` state, dependency-aware task graphs, re-anchoring, and cross-model reviews.",
+  "codex_relation": "primary",
+  "category": "Codex Workflow Frameworks",
+  "tags": [
+    "workflow-state",
+    "task-control"
+  ],
+  "signals": [
+    "durable-state",
+    "dependency-graph",
+    "receipts",
+    "blocked-task-handling"
+  ],
+  "evidence": [
+    "Treats `.flow` as durable workflow state rather than leaving progress inside one chat session.",
+    "Uses dependency-aware execution, receipts, and re-anchoring to steer long-running work before drift accumulates into late-stage review pain."
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
- add gmickel/flow-next to the Codex Workflow Frameworks section
- add Vinix24/vnx-orchestration to the Codex Workflow Frameworks section
- add the corresponding repo metadata entries under data/repos/

## Notes
- the README was regenerated from repo data after updating the entries
- the two summaries were tightened to reduce vague phrasing and better reflect each project's actual workflow surface