### PR TITLE
Add researched Codex workflow candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Official building blocks appear here alongside ecosystem standards that help mak
 - [OpenAI/codex](https://github.com/openai/codex) - Official Codex repository, providing the execution runtime that Codex-native workflow layers and orchestration tools build on.
 - [OpenAI/skills](https://github.com/openai/skills) - Official skill catalog for Codex, showing how reusable instructions, scripts, and resources are packaged into workflow building blocks.
 - [agentsmd/agents.md](https://github.com/agentsmd/agents.md) - Community-led `AGENTS.md` format that gives Codex and neighboring tools a shared way to express repository-local workflow guidance.
+- [OpenAI/symphony](https://github.com/openai/symphony) - Open-source Codex orchestration spec with an Elixir reference implementation, defining issue-tracker-driven workflows where each issue claims a workspace and is driven to a review handoff.
 
 ## Codex Workflow Frameworks
 
@@ -45,12 +46,14 @@ These are the repositories where the workflow itself is the product: planning, e
 - [shinpr/codex-workflows](https://github.com/shinpr/codex-workflows) - Codex workflows organized around user-value slices so features get designed, tested, and integrated earlier instead of breaking at the end; each slice is grounded in design docs, test skeletons, TDD, and quality gates.
 - [Vinix24/vnx-orchestration](https://github.com/Vinix24/vnx-orchestration) - Governance-first workflow runtime for Codex, Claude Code, and Gemini CLI that coordinates parallel agents across tmux panes with an append-only receipt ledger, quality gates, worktrees, and automatic context rotation.
 - [Yeachan-Heo/oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - Workflow layer for Codex organized around OMX modes like `$deep-interview`, `$ralplan`, `$ralph`, and `$team`, giving one repeatable path from clarification to completion.
+- [yimwoo/hotl-plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-loop workflow plugin for Codex, Claude Code, and Cline that turns designs into executable workflow files with per-step verification, persisted run state, human gates for risky steps, and explicit branch/worktree finish decisions.
 
 ## Workflow Infrastructure & Design
 
 These repositories help people design, support, or operate Codex workflows, even when the workflow itself lives elsewhere.
 
 - [berabuddies/agentflow](https://github.com/berabuddies/agentflow) - Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.
+- [max-sixty/worktrunk](https://github.com/max-sixty/worktrunk) - Git worktree management CLI for parallel AI agent workflows, with lifecycle hooks, merge cleanup, project command approvals, and a reusable skill for operating many Codex or Claude sessions safely.
 - [milisp/codexia](https://github.com/milisp/codexia) - Tauri-based desktop console for Codex and Claude Code, built to run many agent tasks at once with scheduling, worktrees, remote control, and a headless web companion.
 - [SaehwanPark/meta-harness](https://github.com/SaehwanPark/meta-harness) - Codex-oriented adaptation of revfactory/harness for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.

--- a/data/repos/max-sixty--worktrunk.json
+++ b/data/repos/max-sixty--worktrunk.json
@@ -1,0 +1,20 @@
+{
+  "name": "max-sixty/worktrunk",
+  "url": "https://github.com/max-sixty/worktrunk",
+  "summary": "Git worktree management CLI for parallel AI agent workflows, with lifecycle hooks, merge cleanup, project command approvals, and a reusable skill for operating many Codex or Claude sessions safely.",
+  "codex_relation": "adjacent",
+  "category": "Workflow Infrastructure & Design",
+  "tags": [
+    "worktrees",
+    "parallel-agents"
+  ],
+  "signals": [
+    "worktree-lifecycle",
+    "hooks",
+    "merge-management"
+  ],
+  "evidence": [
+    "Provides worktree lifecycle automation, hooks, merge cleanup, and agent-oriented documentation for parallel Codex and other CLI-agent workflows."
+  ],
+  "status": "active"
+}

--- a/data/repos/openai--symphony.json
+++ b/data/repos/openai--symphony.json
@@ -1,0 +1,23 @@
+{
+  "name": "OpenAI/symphony",
+  "url": "https://github.com/openai/symphony",
+  "summary": "Open-source Codex orchestration spec with an Elixir reference implementation, defining issue-tracker-driven workflows where each issue claims a workspace and is driven to a review handoff.",
+  "codex_relation": "primary",
+  "category": "Foundations & Standards",
+  "tags": [
+    "official",
+    "orchestration",
+    "spec"
+  ],
+  "signals": [
+    "codex-app-server",
+    "issue-tracker",
+    "workspace-isolation",
+    "handoff"
+  ],
+  "evidence": [
+    "Defines a language-agnostic Symphony service spec for polling issue trackers, claiming eligible work, creating per-issue workspaces, running Codex app-server sessions, retrying stalled work, and reconciling tracker state.",
+    "The Elixir reference workflow uses Linear states, a persistent workpad, validation requirements, PR feedback sweeps, and Human Review / Merging / Done handoff states rather than supervising individual Codex sessions by hand."
+  ],
+  "status": "experimental"
+}

--- a/data/repos/yimwoo--hotl-plugin.json
+++ b/data/repos/yimwoo--hotl-plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "yimwoo/hotl-plugin",
+  "url": "https://github.com/yimwoo/hotl-plugin",
+  "summary": "Human-on-the-loop workflow plugin for Codex, Claude Code, and Cline that turns designs into executable workflow files with per-step verification, persisted run state, human gates for risky steps, and explicit branch/worktree finish decisions.",
+  "codex_relation": "primary",
+  "category": "Codex Workflow Frameworks",
+  "tags": [
+    "workflow",
+    "verification"
+  ],
+  "signals": [
+    "codex-plugin",
+    "executable-workflows",
+    "quality-gates",
+    "durable-state",
+    "worktree"
+  ],
+  "evidence": [
+    "Provides Codex plugin/native-skill entry points plus Codex-specific helper scripts for current-step visibility, execution summaries, and final summaries.",
+    "Defines workflow files as execution contracts with action, verify, gate, loop, and retry semantics, while `hotl-rt` persists authoritative run state and reports under `.hotl/`.",
+    "Routes risky or security-sensitive changes through human-review gates and forces explicit finish disposition for merge, publish, keep, discard, or defer."
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
- Add OpenAI/symphony to Foundations & Standards as an official Codex orchestration spec with an Elixir reference implementation
- Add yimwoo/hotl-plugin to Codex Workflow Frameworks for executable HOTL workflow files, persisted run state, verification, and human gates for risky steps
- Add max-sixty/worktrunk to Workflow Infrastructure & Design as worktree lifecycle infrastructure for parallel agent workflows

## Validation
- npm run check:data
- npm run check:readme

## Notes
- Reviewed adjacent candidates and kept borderline projects on the local watchlist when Codex was not first-class enough, the project was too early, or the workflow scope was narrower than this list.