### PR TITLE
Add Bring Your AI workflow migration artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These repositories help people design, support, or operate Codex workflows, even
 - [milisp/codexia](https://github.com/milisp/codexia) - Tauri-based desktop console for Codex and Claude Code, built to run many agent tasks at once with scheduling, worktrees, remote control, and a headless web companion.
 - [SaehwanPark/meta-harness](https://github.com/SaehwanPark/meta-harness) - Codex-oriented adaptation of revfactory/harness for turning orchestration ideas into reusable specialist skills, team specs, and file-based handoffs instead of one-off prompts.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.
+- [unitedideas/bringyour-mcp](https://github.com/unitedideas/bringyour-mcp) - Public no-data MCP metadata, Codex skill, and subagent artifacts for auditing Claude Code to Codex harness migration before Codex edits code.
 - [xintaofei/codeg](https://github.com/xintaofei/codeg) - Shared coding workspace for multi-agent teams, tying together session aggregation, worktrees, MCP management, browser access, and chat-channel control across desktop and server surfaces.
 
 ## Cross-Agent References

--- a/data/repos/unitedideas--bringyour-mcp.json
+++ b/data/repos/unitedideas--bringyour-mcp.json
@@ -1,0 +1,22 @@
+{
+  "name": "unitedideas/bringyour-mcp",
+  "url": "https://github.com/unitedideas/bringyour-mcp",
+  "summary": "Public no-data MCP metadata, Codex skill, and subagent artifacts for auditing Claude Code to Codex harness migration before Codex edits code.",
+  "codex_relation": "adjacent",
+  "category": "Workflow Infrastructure & Design",
+  "tags": [
+    "migration",
+    "mcp",
+    "skills"
+  ],
+  "signals": [
+    "migration-audit",
+    "validation-notes",
+    "no-data-mcp"
+  ],
+  "evidence": [
+    "Includes a bringyour-migration-auditor Codex skill and harness-migration-auditor subagent for checking instruction scope, hooks, MCP config, skills, and validation notes.",
+    "The remote MCP is documented as no-data and routes users to a local CLI flow, so harness files and secret values stay out of hosted infrastructure."
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
Adds `unitedideas/bringyour-mcp` to Workflow Infrastructure & Design.

The fit is the Codex migration workflow surface: a no-data MCP endpoint, a Codex skill, and a subagent for auditing Claude Code -> Codex harness migration before Codex edits code. The artifacts focus on instruction scope, hooks, MCP config, skills, and validation notes rather than a generic prompt pack.

Validation run: `npm run check:all`.