### PR TITLE
Fix labeler permissions for fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Labeler
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 jobs:
@@ -12,9 +12,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-
       - name: Apply path-based labels
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

- Run the labeler on `pull_request_target` so fork PRs can receive labels with `pull-requests: write`.
- Remove checkout from the labeler workflow so the privileged job does not check out or execute untrusted PR code.

## Notes

This addresses the `Resource not accessible by integration` failure seen on fork PRs where the `pull_request` token is read-only. The normal CI workflow remains on `pull_request`.