### PR TITLE
Add Agentplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ These are the repositories where the workflow itself is the product: planning, e
 
 These repositories help people design, support, or operate Codex workflows, even when the workflow itself lives elsewhere.
 
+- [basilisk-labs/agentplane](https://github.com/basilisk-labs/agentplane) - Git-native harness engineering layer for Codex and other coding agents, organizing work around task contracts, approved plans, verification records, and Agent Change Records tracked directly in Git.
 - [berabuddies/agentflow](https://github.com/berabuddies/agentflow) - Graph-based orchestration runtime for Codex, Claude, and Kimi that treats workflows as dependency graphs, enabling fanout, merge, iterative loops, worktrees, and remote execution.
 - [boshu2/agentops](https://github.com/boshu2/agentops) - DevOps-style operations layer for Codex CLI, Claude Code, Cursor, and OpenCode that persists handoffs, retros, and learnings in `.agents/`, then uses ratchet gates, multi-model councils, pre-mortems, and vibe checks so coding workflows carry evidence and compound knowledge across sessions.
 - [luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first session audit tool for Codex and other coding agents, turning run logs into operational evidence for post-run review, baseline comparison, and CI gates across spend, token use, timing, health, and tool failures.

--- a/data/repos/basilisk-labs--agentplane.json
+++ b/data/repos/basilisk-labs--agentplane.json
@@ -1,0 +1,28 @@
+{
+  "name": "basilisk-labs/agentplane",
+  "url": "https://github.com/basilisk-labs/agentplane",
+  "summary": "Git-native harness engineering layer for Codex and other coding agents, organizing work around task contracts, approved plans, verification records, and Agent Change Records tracked directly in Git.",
+  "codex_relation": "adjacent",
+  "category": "Workflow Infrastructure & Design",
+  "tags": [
+    "workflow-control",
+    "evidence",
+    "git",
+    "worktrees"
+  ],
+  "signals": [
+    "agent-change-records",
+    "task-contracts",
+    "verification-evidence",
+    "workflow-contract",
+    "worktree-pr-flow",
+    "recovery-paths"
+  ],
+  "evidence": [
+    "Defines a repo-local lifecycle around coding-agent work: task, plan, approve, implement, verify, and finish, with direct and branch_pr modes.",
+    "Treats `.agentplane/WORKFLOW.md` as an executable control surface with schema validation, required prompt/check/fallback sections, atomic publish, and last-known-good restore.",
+    "Stores task state, PR artifacts, verification records, and Agent Change Records inside the repository so reviewers do not need to rely on chat transcripts or terminal scrollback.",
+    "Includes route-decision, preflight, doctor, restore, ACR validation/check/explain, evidence bundle, CI contract, and release gate surfaces that make failures typed and recoverable."
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
## Summary
- Add basilisk-labs/agentplane to Workflow Infrastructure & Design
- Include structured repo metadata for README generation
- Regenerate the README repository list

## Validation
- node scripts/validate-repos.mjs
- node scripts/generate-readme.mjs