### PR TITLE
Add codex-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These repositories help people design, support, or operate Codex workflows, even
 - [OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files) - File-backed planning infrastructure for Codex and other agent CLIs, combining lifecycle hooks, isolated planning sessions, plan attestation, run ledgers, and optional completion gates tied to plan state.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.
 - [xintaofei/codeg](https://github.com/xintaofei/codeg) - Shared coding workspace for multi-agent teams, tying together session aggregation, worktrees, MCP management, browser access, and chat-channel control across desktop and server surfaces.
+- [zhuhaow/codex-fixes](https://github.com/zhuhaow/codex-fixes) - Community-maintained Codex issue registry and CLI for diagnosing known bugs, previewing applicable fixes, and applying platform-scoped workarounds.
 
 ## Cross-Agent References
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ These repositories help people design, support, or operate Codex workflows, even
 - [OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files) - File-backed planning infrastructure for Codex and other agent CLIs, combining lifecycle hooks, isolated planning sessions, plan attestation, run ledgers, and optional completion gates tied to plan state.
 - [strongdm/leash](https://github.com/strongdm/leash) - Runtime containment and policy layer for AI coding agents that makes Codex workflows safer by wrapping agents in monitored containers and enforcing Cedar policies in real time.
 - [xintaofei/codeg](https://github.com/xintaofei/codeg) - Shared coding workspace for multi-agent teams, tying together session aggregation, worktrees, MCP management, browser access, and chat-channel control across desktop and server surfaces.
-- [zhuhaow/codex-fixes](https://github.com/zhuhaow/codex-fixes) - Community-maintained Codex issue registry and CLI for diagnosing known bugs, previewing applicable fixes, and applying platform-scoped workarounds.
+- [zhuhaow/codex-fixes](https://github.com/zhuhaow/codex-fixes) - Checks your local Codex install for known issues and runs the matching community-maintained fix scripts.
 
 ## Cross-Agent References
 

--- a/data/repos/zhuhaow--codex-fixes.json
+++ b/data/repos/zhuhaow--codex-fixes.json
@@ -1,7 +1,7 @@
 {
   "name": "zhuhaow/codex-fixes",
   "url": "https://github.com/zhuhaow/codex-fixes",
-  "summary": "Community-maintained Codex issue registry and CLI for diagnosing known bugs, previewing applicable fixes, and applying platform-scoped workarounds.",
+  "summary": "Checks your local Codex install for known issues and runs the matching community-maintained fix scripts.",
   "codex_relation": "primary",
   "category": "Workflow Infrastructure & Design",
   "tags": [
@@ -12,13 +12,13 @@
   "signals": [
     "codex-cli",
     "issue-manifests",
-    "platform-targets",
+    "codex-targets",
     "dry-run",
     "fix-scripts"
   ],
   "evidence": [
-    "Ships a `codex-fixes` CLI with `doctor`, `show`, `apply`, and `--dry-run` commands for inspecting and running Codex-specific fixes.",
-    "Stores issue manifests and platform-scoped fix scripts under `registry/issues/`, with target metadata for Codex CLI and Desktop surfaces.",
+    "Ships a `codex-fixes` CLI with `doctor`, `show`, `apply`, and `--dry-run` commands for checking the local Codex environment and running matching fixes.",
+    "Stores issue manifests and target-specific fix scripts under `registry/issues/`, with target metadata for Codex CLI and Desktop surfaces.",
     "Documents a community workflow for reporting real Codex bugs, sharing workarounds, verifying platforms, and marking upstream fixes."
   ],
   "status": "active"

--- a/data/repos/zhuhaow--codex-fixes.json
+++ b/data/repos/zhuhaow--codex-fixes.json
@@ -1,0 +1,25 @@
+{
+  "name": "zhuhaow/codex-fixes",
+  "url": "https://github.com/zhuhaow/codex-fixes",
+  "summary": "Community-maintained Codex issue registry and CLI for diagnosing known bugs, previewing applicable fixes, and applying platform-scoped workarounds.",
+  "codex_relation": "primary",
+  "category": "Workflow Infrastructure & Design",
+  "tags": [
+    "diagnostics",
+    "workarounds",
+    "issue-registry"
+  ],
+  "signals": [
+    "codex-cli",
+    "issue-manifests",
+    "platform-targets",
+    "dry-run",
+    "fix-scripts"
+  ],
+  "evidence": [
+    "Ships a `codex-fixes` CLI with `doctor`, `show`, `apply`, and `--dry-run` commands for inspecting and running Codex-specific fixes.",
+    "Stores issue manifests and platform-scoped fix scripts under `registry/issues/`, with target metadata for Codex CLI and Desktop surfaces.",
+    "Documents a community workflow for reporting real Codex bugs, sharing workarounds, verifying platforms, and marking upstream fixes."
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
Adds zhuhaow/codex-fixes to Workflow Infrastructure & Design.

codex-fixes is a small registry and CLI for known Codex issues. It checks a local Codex install, shows which issues apply, and can run the matching community-maintained fix script.

Validation:
- npm run generate:readme
- npm run check:all
